### PR TITLE
BEAR-14520 update to ruby2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,7 +15,7 @@ AllCops:
     - log/**/*
     - tmp/**/*
     - db/**/*
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
 
 Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be an Integer or


### PR DESCRIPTION
## チケット
[\[BEAR-14583\] \[naosukeの20%\] kuma componentsのRuby2.5対応](https://nttcom.atlassian.net/browse/BEAR-14583)

## やったこと
<!---
箇条書きで, 簡単に変更内容を記入してください
-->
- rubocop のTargetRubyVersionを2.5に変更
- PullReq templateの追加

## see also
[Pull Request時のお約束](https://nttcom.atlassian.net/wiki/spaces/BEAR/pages/389154436/Pull+Request)